### PR TITLE
Ensure linters config files are honored

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,9 @@ If you add support for additional linters, please
 
 - update the `install.py` file
 
-- update the `README.md` file
+- update the `pre_commit/pre-commit` file
 
-- update the `pre_commit/uninstall.py` file, if needed.
+- update the `README.md` file.
 
 <!-- markdownlint-disable MD026-->
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ follows) with:
 <!-- markdownlint-enable MD001 MD002 -->
 ```
 
-More configuration options can be specified with e.g. a
-[`.mdlrc`](https://github.com/markdownlint/markdownlint/blob/master/docs/configuration.md#mdl-configuration)
-file.
+More configuration options can be specified by including
+[`.markdownlint.json`](https://github.com/igorshubovych/markdownlint-cli#configuration)
+file in the root of your local repository.
 
 ### Python - `flake8`
 
@@ -237,8 +237,9 @@ b =2 # noqa
 You can exclude specific errors on a line with `# noqa: <error>`,
 e.g. `# noqa: E234`.
 
-More configuration options can be specified with e.g. a
-[`.flake8`](http://flake8.pycqa.org/en/latest/user/configuration.html) file.
+More configuration options can be specified by including a
+[`.flake8`](http://flake8.pycqa.org/en/latest/user/configuration.html) file
+in the root of your local repository.
 
 ### R - `lintr`
 
@@ -268,8 +269,9 @@ b =2
 x <- c(1,2, 3)
 ```
 
-More configuration options can be specified with e.g. a
-[`.lintr`](https://github.com/jimhester/lintr#project-configuration) file.
+More configuration options can be specified by including a
+[`.lintr`](https://github.com/jimhester/lintr#project-configuration) file
+in the root of your local repository.
 
 ## Useful links
 

--- a/pre_commit/lint.py
+++ b/pre_commit/lint.py
@@ -25,9 +25,9 @@ class Lint(object):
     def __init__(self, git_handle, linters, *args, **kwargs):
         """
         Args:
-            git_handle: a `GitHandle` instance for the repository of interest
+            git_handle: a `GitHandle` instance for the repository of interest.
             linters: an iterable of `Linter` objects
-            (see `pre_commit.linters`).
+                (see `pre_commit.linters`).
         """
         # get the input git handle
         self.git_handle = git_handle

--- a/pre_commit/linters.py
+++ b/pre_commit/linters.py
@@ -102,7 +102,7 @@ class MarkdownLinter(Linter):
     A wrapper for "markdownlint".
     """
 
-    def __init__(self, config_path):
+    def __init__(self, config_path=""):
         super().__init__(".md", config_path)
 
     def linter_process(self, f):
@@ -125,7 +125,7 @@ class PythonLinter(Linter):
     A wrapper for "flake8".
     """
 
-    def __init__(self, config_path):
+    def __init__(self, config_path=""):
         super().__init__(".py", config_path)
 
     def linter_process(self, f):
@@ -147,7 +147,7 @@ class RLinter(Linter):
     A wrapper for "lintr".
     """
 
-    def __init__(self, config_path):
+    def __init__(self, config_path=""):
         super().__init__((".r", ".R"), config_path)
 
     def linter_process(self, f):

--- a/pre_commit/pre-commit
+++ b/pre_commit/pre-commit
@@ -12,13 +12,31 @@ from pre_commit.linters import (
     PythonLinter,
     RLinter
 )
-from pre_commit.util import get_config
+from pre_commit.util import (
+    get_config,
+    get_linter_config
+)
+
+# instantiate git handle
+git_handle = GitHandle()
 
 # parse linters configuration file and create `linters` argument for `Lint()`
 available_linters = {
-    "markdown": MarkdownLinter(),
-    "python": PythonLinter(),
-    "r": RLinter()
+    "markdown": MarkdownLinter(
+        config_path=get_linter_config(
+            path.join(git_handle.root, ".markdownlint.json")
+        )
+    ),
+    "python": PythonLinter(
+        config_path=get_linter_config(
+            path.join(git_handle.root, ".flake8")
+        )
+    ),
+    "r": RLinter(
+        config_path=get_linter_config(
+            path.join(git_handle.root, ".lintr")
+        )
+    )
 }
 
 linters = []
@@ -41,5 +59,5 @@ sys.tracebacklimit = 0
 
 # execute linting
 sys.exit(
-    Lint(git_handle=GitHandle(), linters=linters).run()
+    Lint(git_handle=git_handle, linters=linters).run()
 )

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -54,7 +54,7 @@ def get_linter_config(pth):
     Returns the input path if it exists, otherwise "".
 
     Args:
-        pth: a file path,
+        pth: a file path.
 
     Returns:
         Returns its input if the path exists and "" otherwise.

--- a/pre_commit/util.py
+++ b/pre_commit/util.py
@@ -3,7 +3,8 @@ from configparser import ConfigParser
 from contextlib import contextmanager
 from os import (
     chdir,
-    getcwd
+    getcwd,
+    path
 )
 
 
@@ -28,21 +29,34 @@ def exec_in_dir(_dir):
 def get_config(section, option, conf_file_path):
     """
     Returns the value of an option stored in a section
-    of a configuration file
+    of a configuration file.
 
     Args:
         section: a string corresponding to the name of a section of a
-            configuration file
+            configuration file.
         option: a string corresponding to an option contained in a section
-            of a configuration file
-        conf_file_path: full path to the configuration file
+            of a configuration file.
+        conf_file_path: full path to the configuration file.
 
     Returns:
-        a string, corresponding to the value of the target option in the
-        target section
+        A string, corresponding to the value of the target option in the
+        target section.
     """
     parser = ConfigParser()
 
     parser.read(conf_file_path)
 
     return parser.get(section, option)
+
+
+def get_linter_config(pth):
+    """
+    Returns the input path if it exists, otherwise "".
+
+    Args:
+        pth: a file path,
+
+    Returns:
+        Returns its input if the path exists and "" otherwise.
+    """
+    return pth if path.exists(pth) else ""

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -71,6 +71,40 @@ class TestMarkdownLinter(TestCase):
             # clean up
             w.delete()
 
+    def test_linter_config_file(self):
+        try:
+            # write the `markdownlint.json` config file instructing to
+            # except "MD022/blanks-around-headers"
+            config_file_path = path.join(self.cwd, ".markdownlint.json")
+            w_conf = Writer(config_file_path)
+            w_conf.write("{")
+            w_conf.write('    "MD022": false')
+            w_conf.write("}")
+
+            # write a bad markdown file
+            file_path = path.join(self.cwd, "test.md")
+            w = Writer(file_path)
+            w.write("# Section")
+            w.write("Missing a blank line after header.")
+
+            # instantiate the linter (sink STDOUT in testing)
+            f = StringIO()
+            with redirect_stdout(f):
+                return_value = (
+                    MarkdownLinter(config_path=w_conf.path).lint([w.path])
+                )
+
+            # return value will be 0 if MD022 is correctly ignored
+            self.assertEqual(return_value, 0)
+
+        except Exception:
+            raise
+
+        finally:
+            # clean up
+            w_conf.delete()
+            w.delete()
+
 
 class TestPythonLinter(TestCase):
 
@@ -78,7 +112,7 @@ class TestPythonLinter(TestCase):
 
     def test_zero_exit_code(self):
         try:
-            # write a bad markdown file
+            # write a bad python file
             file_path = path.join(self.cwd, "test.py")
             w = Writer(file_path)
             w.write("# This is ok")
@@ -108,7 +142,7 @@ class TestPythonLinter(TestCase):
             w.write("# No space around =")
             w.write("foo=1")
 
-            # instantiate the linter
+            # instantiate the linter (sink STDOUT in testing)
             f = StringIO()
             with redirect_stdout(f):
                 return_value = PythonLinter().lint([w.path])
@@ -122,6 +156,39 @@ class TestPythonLinter(TestCase):
             # clean up
             w.delete()
 
+    def test_linter_config_file(self):
+        try:
+            # write the `.flake8` config file instructing to
+            # except "E225"
+            config_file_path = path.join(self.cwd, ".flake8")
+            w_conf = Writer(config_file_path)
+            w_conf.write("[flake8]")
+            w_conf.write("ignore = E225")
+
+            # write a bad python file
+            file_path = path.join(self.cwd, "test.py")
+            w = Writer(file_path)
+            w.write("# No space around =")
+            w.write("foo=1")
+
+            # instantiate the linter (sink STDOUT in testing)
+            f = StringIO()
+            with redirect_stdout(f):
+                return_value = (
+                    PythonLinter(config_path=w_conf.path).lint([w.path])
+                )
+
+            # return value will be 0 if E225 is correctly ignored
+            self.assertEqual(return_value, 0)
+
+        except Exception:
+            raise
+
+        finally:
+            # clean up
+            w_conf.delete()
+            w.delete()
+
 
 class TestRLinter(TestCase):
 
@@ -129,7 +196,7 @@ class TestRLinter(TestCase):
 
     def test_zero_exit_code(self):
         try:
-            # write a bad markdown file
+            # write a bad R file
             file_path = path.join(self.cwd, "test.R")
             w = Writer(file_path)
             w.write("# This is ok")
@@ -153,13 +220,13 @@ class TestRLinter(TestCase):
 
     def test_non_zero_exit_code(self):
         try:
-            # write a bad python file
+            # write a bad R file
             file_path = path.join(self.cwd, "test.R")
             w = Writer(file_path)
             w.write("# Use = instead of <-")
             w.write("bar = 0")
 
-            # instantiate the linter
+            # instantiate the linter (sink STDOUT in testing)
             f = StringIO()
             with redirect_stdout(f):
                 return_value = RLinter().lint([w.path])
@@ -171,6 +238,39 @@ class TestRLinter(TestCase):
 
         finally:
             # clean up
+            w.delete()
+
+    def test_linter_config_file(self):
+        try:
+            # write the `.lintr` config file instructing to
+            # deactivate the "assignment_linter"
+            config_file_path = path.join(self.cwd, ".lintr")
+            w_conf = Writer(config_file_path)
+            w_conf.write("linters: with_defaults(assignment_linter = NULL)")
+
+            # write a bad R file
+            file_path = path.join(self.cwd, "test.R")
+            w = Writer(file_path)
+            w.write("# Use = instead of <-")
+            w.write("bar = 0")
+
+            # instantiate the linter
+            f = StringIO()
+            with redirect_stdout(f):
+                return_value = (
+                    RLinter(config_path=w_conf.path).lint([w.path])
+                )
+
+            # return value will be 0 if the "assignment_linter" is correctly
+            # deactivated
+            self.assertEqual(return_value, 0)
+
+        except Exception:
+            raise
+
+        finally:
+            # clean up
+            w_conf.delete()
             w.delete()
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,6 +16,7 @@ from unittest import (
 
 from pre_commit.util import (
     get_config,
+    get_linter_config,
     exec_in_dir
 )
 
@@ -93,6 +94,50 @@ class TestGetConfig(TestCase):
             self.assertEqual(
                 get_config("section2", "option2", test_config_path),
                 "bar"
+            )
+
+        except Exception:
+            raise
+
+        finally:
+            # clean up
+            remove(path.abspath(test_config_path))
+
+
+class TestGetLinterConfig(TestCase):
+
+    cwd = getcwd()
+
+    def test_get_linter_config_without_file(self):
+
+        try:
+            # path to a config file
+            test_config_path = path.join(self.cwd, ".config")
+
+            # test return value when file does not exist
+            self.assertEqual(
+                get_linter_config(test_config_path),
+                ""
+            )
+
+        except Exception:
+            raise
+
+    def test_get_linter_config_with_file(self):
+
+        try:
+            # path to a config file
+            test_config_path = path.join(self.cwd, ".config")
+
+            # test return value when file exists
+            with open(test_config_path, "w") as foo:
+                foo.write("[linter]\n")
+                foo.write("ignore=error_code")
+
+            # test
+            self.assertEqual(
+                get_linter_config(test_config_path),
+                test_config_path
             )
 
         except Exception:


### PR DESCRIPTION
# Honoring the linters config files

This PR ensures that `.markdownlint.json`, `.flake8`, and `.lintr` are honored.

This is achieved by adding the `--config CONFIG_FILE` option to the calls to `flake8` and `markdownlint` if the value of the `config_path` attribute of the corresponding `Linter` instances is specified at the instance initialization.

For `lintr`, the story is a little more complicated because it looks like there is no way to pass a the path to the `.lintr` config file manually. For the moment, this is handled using a hacky solution: the `.lintr` config file is copied from the root of the repository to the working directory of the R session running the `RLinter` instance.

# Other

This PR also

- fixes some minor issues in the docstrings, the README files, etc.

- moves the extension attribute of the `Linter` class to `__init__`.